### PR TITLE
Update uri to beecrowd and add infos in readme

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -4,11 +4,14 @@
 
 ## Sumário
 
+- [Sobre esse repositório](#sobre-esse-repositório)
+  - [Sumário](#sumário)
 - [Sites com exercícios](#sites-com-exercícios)
 - [IDE's online](#ides-online)
 - [Outras Ferramentas](#outras-ferramentas)
 - [Extras](#extras)
 - [API](#api)
+- [Verificar](#verificar)
 
 # Sites com exercícios
 - *Sites com exercícios para treinar*
@@ -30,7 +33,7 @@
 |[Hacker Rank](https://www.hackerrank.com)| SIM | Não | Angular, C#, CSS, Go, Java, JavaScript, Node, Node.js, Python, R, React, Rest API, SQL e etc. | Modos básicos e intermediários |
 |[Khan Academy](https://pt.khanacademy.org) | Sim | Não | Lógica e outras disciplinas | --------- |
 |[Koans Kotling](https://play.kotlinlang.org/koans/Introduction/Hello,%20world!/Task.kt)| Não | Não | Kotlin | Teste de estruturas Kotlin para aprendizado |
-|[URI On Line](https://www.urionlinejudge.com.br) | SIM | Não | C, C++, C#, Clojure, Dart, Go, Haskell, Java, JavaScript, Kotlin,  PHP, Python, R, Ruby, Rust e Scala  | 6 Modos desde o iniciante, com Hello World! |
+|[beecrowd](https://www.beecrowd.com.br/) | SIM | Não | C, C++, C#, Clojure, Dart, Go, Haskell, Java, JavaScript, Kotlin,  PHP, Python, R, Ruby, Rust e Scala  | 6 Modos desde o iniciante, com Hello World! |
 |[Kaggle](https://www.kaggle.com/) | SIM | Não | Python, R, SQL | Maior site de referência para aprendizado de Data Science, Machine Learn e afins |
 |[LeetCode](https://leetcode.com/) | SIM | Não | C, C++, C#, Go, Java, JavaScript, Kotlin, PHP, Python, Python3, R, Ruby, Rust, MySQL, MS SQL, Oracle, Bash, Swift, Rust, Typescript, Racket, Erlang e Elixir | Site muito bom para treinar programação e estudar pra entrevista de código, tem módulos básicos, intermediários e avançados. Sessão com materiais de estudos com prática e contest toda semana. |
 |[Grid Garden](https://cssgridgarden.com/) | Não | Não | CSS | Site para aprender e treinar css grid layout |
@@ -72,6 +75,7 @@
 |[Cron App](https://www.cronapp.io/) | Não | Diversas  | Plataforma de desenvolvimento de projetos de aplicações web em nuvem |
 |[Read Me](https://readme.so/editor)| Não | Read Me | Site para criação de ReadMe para seus projetos |
 |[Free for Dev](https://free-for.dev/)| Não | Diversas | Site com serviços, ferramentas e recursos gratuitos para devs (hospedagem, cloud, monitoramento, testes, etc)
+|[Carbon](https://carbon.vercel.app/)| Não | Diversas | Site para criar e compartilhar bonitas imagens do seu codigo
 
 # Extras
 - *Cursos, vídeo aulas, etc. gratuitos*
@@ -97,6 +101,7 @@
 |[App Ideas](https://github.com/florinpop17/app-ideas)| Repositório com desafios de programação desde o iniciante até projetos avançados | Florin Pop |
 |[Vue3 do Iniciante ao Avançado](https://igorhalfeld.teachable.com/p/treinamento-completo-e-gratuito-de-vue-js-3-do-iniciante-ao-avancado) | Curso completo de Vue3 | Igor Halfeld
 |[AWS Training](https://www.aws.training/) | Treinamentos AWS com ferramentas e suporte para as certificações | AWS |
+|[Assert+](https://www.assertplus.com.br/) | Conteúdo em geral sobre qualidade e testes de software | [Jhonatas Matos](https://github.com/jhonatasmatos) |
 
 # API
 - *Sites com concentração de API's para projetos*
@@ -107,6 +112,7 @@
 |[BrasilAPI](https://brasilapi.com.br/docs) | Projeto de código aberto, que transforma o Brasil em uma API | Comunidade |
 |[Public APIs](https://github.com/public-apis/public-apis)| Repositório com várias APIs gratuitas dos mais diversos assuntos|Public APIs|
 |[Any API](https://any-api.com/)| Site com diversas apis abertas de diversos nichos | LucyBot Inc.|
+|[ServeRest](https://serverest.dev/)| O ServeRest é uma API REST gratuita que simula uma loja virtual com intuito de servir de material de estudos de testes de API | [Paulo Gonçalves](https://github.com/PauloGoncalvesBH) |
 
 
 <!--

--- a/criadores.md
+++ b/criadores.md
@@ -46,4 +46,5 @@ Pessoas que produzem vídeos sobre tecnologia
 |[AttekitaDev](https://beacons.page/attekitadev) | Web, Mobile, Games e Carreira | [YouTube](https://www.youtube.com/c/AttekitaDev) | ------- |
 |[Loiane Groner](https://loiane.training/sobre) | Java, Angular, Spring, VS Code | [YouTube](https://www.youtube.com/c/loianegroner) | ------- |
 |[Kamila Santos](https://beacons.page/kamila_code) | Java, Spring, Backend, Cloud computing | [YouTube](https://www.youtube.com/Kamilacode) | ------- |
+|[Jhonatas Matos](https://github.com/jhonatasmatos) | Testes de software, Tecnicas de testes e automação de testes | [YouTube](https://www.youtube.com/c/AssertPlus) | ------- |
 


### PR DESCRIPTION
Uri online judge agora é beecrowd, então alterei o link e o nome

Adicionei o link para o carbon uma tool que facilita compartilhar imagem de codigo de uma forma "bonita"

Adicionei um criador de conteudo da area de qualidade de software

Adicionei a API do ServeRest que tem ajudado a comunidade de testes a praticar testes em API

