### PR TITLE
Adição do site refactoring.guru e do curso da unity

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -125,6 +125,8 @@
 | [DIO](https://www.dio.me/) | Plataforma de cursos e bootcamps gratuitos em tecnologia | Digital Innovation One |
 | [Microsoft ConectAI Desenvolvedores](https://www.microsoft.com/pt-br/conecta/desenvolvedores.aspx) | Mergulhe no universo da Inteligência Artificial, aprenda a criar aplicativos com o Power Platform, prepare-se para as certificações da Microsoft e explore trilhas de aprendizado personalizadas | Microsoft |
 | [Microsoft Reactor](https://developer.microsoft.com/pt-br/reactor/) | O Microsoft Reactor fornece eventos, treinamento e recursos da comunidade para ajudar startups, empreendedores e desenvolvedores a criar seus próximos negócios em tecnologia de IA | Microsoft |
+| [Refactoring.Guru](https://refactoring.guru/pt-br) | Conteúdo sobre refatoração, padrões de projeto e princípios SOLID | Refactoring Guru |
+| [Unity Learn](https://learn.unity.com) | Cursos gratuitos de desenvolvimento de games na Uinty | Unity |
 
 
 # API


### PR DESCRIPTION
Adição do link para site refactoring.guru (PT-BR) sobre padrões de projeto e refatoração de código.
Adição do link do site da Unity com curso gratuitos sobre desenvolvimento de jogos